### PR TITLE
Fix asset registry path

### DIFF
--- a/static/js/assetLoader.js
+++ b/static/js/assetLoader.js
@@ -6,7 +6,11 @@ console.log('[DEBUG] THREE imported:', typeof THREE);
 import { GLTFLoader } from './loaders/GLTFLoader.js';
 console.log('[DEBUG] GLTFLoader imported:', typeof GLTFLoader);
 
-export async function loadExternalAssets(scene, registryUrl = '/static/asset_registry.json') {
+// The asset registry lives under the models directory. The original default
+// path pointed to `/static/asset_registry.json`, which does not exist and
+// results in a failed fetch.  Point to the correct location instead so assets
+// load properly when the game starts.
+export async function loadExternalAssets(scene, registryUrl = '/static/models/asset_registry.json') {
   console.log('[DEBUG] Starting to load external assets from registry:', registryUrl);
   let registry;
   try {


### PR DESCRIPTION
## Summary
- load asset registry from the correct location

## Testing
- `python -m py_compile server.py`
- `node --check static/js/assetLoader.js`


------
https://chatgpt.com/codex/tasks/task_e_6845fae3d39c8327937df3ac13f3a228